### PR TITLE
resolve relative import issues for consistent module access

### DIFF
--- a/cactus/api.py
+++ b/cactus/api.py
@@ -5,7 +5,7 @@ from loguru import logger
 import openai
 import tiktoken
 
-from constants import CLASSIFICATOR_SCHEMA_GEMINI, CLASSIFICATOR_SCHEMA_OPENAI, MODEL_TOKEN_LIMITS, PROMPT_CLASSIFICATOR_SYSTEM
+from .constants import CLASSIFICATOR_SCHEMA_GEMINI, CLASSIFICATOR_SCHEMA_OPENAI, MODEL_TOKEN_LIMITS, PROMPT_CLASSIFICATOR_SYSTEM
 
 import google.generativeai as genai
 from google.generativeai import protos

--- a/cactus/cactus.py
+++ b/cactus/cactus.py
@@ -19,11 +19,11 @@ import os  # Added to handle relative imports
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))  # Add
 
-from api import get_clusters_from_gemini, get_clusters_from_openai, load_api_key, setup_api_key
-from changelog import generate_changelog
-from utils import setup_logging
-from git_utils import run, get_git_diff, restore_changes, parse_diff, stage_changes
-from grouper import parse_diff, stage_changes
+from .api import get_clusters_from_gemini, get_clusters_from_openai, load_api_key, setup_api_key
+from .changelog import generate_changelog
+from .utils import setup_logging
+from .git_utils import run, get_git_diff, restore_changes, parse_diff, stage_changes
+from .grouper import parse_diff, stage_changes
 
 from unidiff import PatchSet
 from loguru import logger
@@ -31,8 +31,7 @@ from loguru import logger
 from prompt_toolkit.shortcuts import print_formatted_text
 from prompt_toolkit.formatted_text import FormattedText
 from prompt_toolkit.styles import Style
-from prompt import display_clusters, handle_user_input
-
+from .prompt import display_clusters, handle_user_input
 
 def extract_patches(diff_data):
     """

--- a/cactus/changelog.py
+++ b/cactus/changelog.py
@@ -1,9 +1,9 @@
 import sys
 from loguru import logger
 
-from constants import MODEL_TOKEN_LIMITS, PROMPT_CHANGELOG_GENERATOR, PROMPT_CHANGELOG_SYSTEM
-from api import num_tokens_from_string, split_into_chunks
-from utils import run
+from .constants import MODEL_TOKEN_LIMITS, PROMPT_CHANGELOG_GENERATOR, PROMPT_CHANGELOG_SYSTEM
+from .api import num_tokens_from_string, split_into_chunks
+from .utils import run
 import google.generativeai as genai
 import openai
 

--- a/cactus/git_utils.py
+++ b/cactus/git_utils.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 from loguru import logger
 from unidiff import PatchSet, UnidiffParseError
-from utils import run
+from .utils import run
 
 
 def get_git_diff(context_size):

--- a/cactus/grouper.py
+++ b/cactus/grouper.py
@@ -3,7 +3,7 @@ import os
 import re
 import numpy as np
 from collections import Counter
-from git_utils import parse_diff, stage_changes
+from .git_utils import parse_diff, stage_changes
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity


### PR DESCRIPTION
Fixes relative module imports when running cactus with a venv. Eliminates the need of explicitly running it calling the interpreter.